### PR TITLE
Per monitor units

### DIFF
--- a/configure
+++ b/configure
@@ -2656,7 +2656,6 @@ END
 fi
 
 
-: ${CFLAGS="-g -O0 -Wall"}
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 AC_INIT([bard], [1.0], [https://github.com/DelusionalLogic/bard/issues])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])
 AC_CONFIG_SRCDIR([src/xlib_color.c])
-: ${CFLAGS="-g -O0 -Wall"}
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG([-std=gnu11],,[AC_MSG_FAILURE([no acceptable C11 compiler found.])])
 AC_PROG_CC_STDC

--- a/src/gdbus/dbus.c
+++ b/src/gdbus/dbus.c
@@ -108,6 +108,8 @@ static void on_bus_aquired(GDBusConnection* conn, const gchar* name, gpointer us
 			"handle-enable-unit",
 			G_CALLBACK(on_handle_enable_unit),
 			userdata);
+
+	dbus_bard_set_config_path(bardbus, dbus->configPath);
 }
 
 static void on_name_aquired(GDBusConnection* conn, const gchar* name, gpointer userdata) {
@@ -137,11 +139,11 @@ static void* workThread(void* userdata) {
 	return NULL;
 }
 
-void dbus_start(struct Dbus* dbus, char* name) {
+void dbus_start(struct Dbus* dbus, char* name, char* configPath) {
 	pipe(dbus->fd);
+	dbus->configPath = configPath;
 	if(pthread_create(&dbus->thread, NULL, workThread, dbus) != 0)
 		VTHROW_NEW("Failed creating dbus thread");
-		return;
 }
 
 void dbus_stop(struct Dbus* dbus) {

--- a/src/gdbus/dbus.c
+++ b/src/gdbus/dbus.c
@@ -1,6 +1,7 @@
 #include "dbus.h"
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include "bard-generated.h"
 #include "logger.h"
 #include "myerror.h"
@@ -8,6 +9,7 @@
 static gboolean on_handle_bar_reload(dbusBard* obj, GDBusMethodInvocation* inv, gpointer userdata) {
 	struct Dbus* dbus = (struct Dbus*)userdata;
 	log_write(LEVEL_INFO, "Dbus told us to restart the bar");
+	log_write(LEVEL_INFO, "Dbus fd %d", dbus->fd[1]);
 
 	struct DbusWork* work = malloc(sizeof(struct DbusWork));
 	work->command = DC_RESTART;
@@ -30,12 +32,51 @@ static gboolean on_handle_reload(dbusBard* obj, GDBusMethodInvocation* inv, gpoi
 	//Should be atomic according to POSIX spec, assuming that PIPE_BUF > 4
 	write(dbus->fd[1], &work, sizeof(&work));
 
-	dbus_bard_complete_bar_reload(obj, inv);
+	dbus_bard_complete_reload(obj, inv);
+
+	return true;
+}
+
+static gboolean on_handle_disable_unit(dbusBard* obj, GDBusMethodInvocation* inv, char* name, int32_t monitor, gpointer userdata) {
+	struct Dbus* dbus = (struct Dbus*)userdata;
+
+	log_write(LEVEL_INFO, "Dbus told us to disable %s, on %d", name, monitor);
+
+	struct DbusWork* work = malloc(sizeof(struct DbusWork));
+	work->command = DC_DISABLEUNIT;
+	work->endis.unitName = malloc(strlen(name) * sizeof(char));
+	strcpy(work->endis.unitName, name);
+	work->endis.monitor = monitor;
+
+	//Should be atomic according to POSIX spec, assuming that PIPE_BUF > 4
+	write(dbus->fd[1], &work, sizeof(&work));
+
+	dbus_bard_complete_disable_unit(obj, inv);
+
+	return true;
+}
+
+static gboolean on_handle_enable_unit(dbusBard* obj, GDBusMethodInvocation* inv, char* name, int32_t monitor, gpointer userdata) {
+	struct Dbus* dbus = (struct Dbus*)userdata;
+
+	log_write(LEVEL_INFO, "Dbus told us to enable %s, on %d", name, monitor);
+
+	struct DbusWork* work = malloc(sizeof(struct DbusWork));
+	work->command = DC_ENABLEUNIT;
+	work->endis.unitName = malloc(strlen(name) * sizeof(char));
+	strcpy(work->endis.unitName, name);
+	work->endis.monitor = monitor;
+
+	//Should be atomic according to POSIX spec, assuming that PIPE_BUF > 4
+	write(dbus->fd[1], &work, sizeof(&work));
+
+	dbus_bard_complete_enable_unit(obj, inv);
 
 	return true;
 }
 
 static void on_bus_aquired(GDBusConnection* conn, const gchar* name, gpointer userdata) {
+	struct Dbus* dbus = (struct Dbus*)userdata;
 	dbusBard* bardbus = dbus_bard_skeleton_new();
 	GError* error = NULL;
 	if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (bardbus),
@@ -56,6 +97,16 @@ static void on_bus_aquired(GDBusConnection* conn, const gchar* name, gpointer us
 	g_signal_connect(G_DBUS_INTERFACE_SKELETON(bardbus),
 			"handle-reload",
 			G_CALLBACK(on_handle_reload),
+			userdata);
+
+	g_signal_connect(G_DBUS_INTERFACE_SKELETON(bardbus),
+			"handle-disable-unit",
+			G_CALLBACK(on_handle_disable_unit),
+			userdata);
+
+	g_signal_connect(G_DBUS_INTERFACE_SKELETON(bardbus),
+			"handle-enable-unit",
+			G_CALLBACK(on_handle_enable_unit),
 			userdata);
 }
 
@@ -89,7 +140,7 @@ static void* workThread(void* userdata) {
 void dbus_start(struct Dbus* dbus, char* name) {
 	pipe(dbus->fd);
 	if(pthread_create(&dbus->thread, NULL, workThread, dbus) != 0)
-		//VTHROW_NEW("Failed creating dbus thread");
+		VTHROW_NEW("Failed creating dbus thread");
 		return;
 }
 

--- a/src/gdbus/dbus.h
+++ b/src/gdbus/dbus.h
@@ -27,9 +27,10 @@ struct Dbus {
 	pthread_t thread;
 	GMainLoop* loop;
 	int fd[2];
+	char* configPath;
 };
 
-void dbus_start(struct Dbus* dbus, char* name);
+void dbus_start(struct Dbus* dbus, char* name, char* configPath);
 void dbus_stop(struct Dbus* dbus);
 
 int dbus_getfd(struct Dbus* dbus);

--- a/src/gdbus/dbus.h
+++ b/src/gdbus/dbus.h
@@ -7,10 +7,20 @@
 enum DbusCommand {
 	DC_RESTART,
 	DC_RELOAD,
+	DC_DISABLEUNIT,
+	DC_ENABLEUNIT,
+};
+
+struct EnDisWork {
+	char* unitName;
+	int monitor;
 };
 
 struct DbusWork {
 	enum DbusCommand command;
+	union {
+		struct EnDisWork endis;
+	};
 };
 
 struct Dbus {

--- a/src/gdbus/dk.slashwin.bard.xml
+++ b/src/gdbus/dk.slashwin.bard.xml
@@ -12,5 +12,6 @@
 			<arg name="unit_name" type="s"/>
 			<arg name="monitor" type="i"/>
 		</method>
+		<property name="ConfigPath" type="s" access="read" />
 	</interface>
 </node>

--- a/src/gdbus/dk.slashwin.bard.xml
+++ b/src/gdbus/dk.slashwin.bard.xml
@@ -1,8 +1,16 @@
 <node>
-  <interface name="dk.slashwin.bard">
-    <method name="BarReload">
-    </method>
-    <method name="Reload">
-    </method>
-  </interface>
+	<interface name="dk.slashwin.bard">
+		<method name="BarReload">
+		</method>
+		<method name="Reload">
+		</method>
+		<method name="DisableUnit">
+			<arg name="unit_name" type="s"/>
+			<arg name="monitor" type="i"/>
+		</method>
+		<method name="EnableUnit">
+			<arg name="unit_name" type="s"/>
+			<arg name="monitor" type="i"/>
+		</method>
+	</interface>
 </node>

--- a/src/main.c
+++ b/src/main.c
@@ -279,7 +279,8 @@ int main(int argc, char **argv)
 
 	struct Bard bard = {0};
 
-	dbus_start(&bard.dbus, "/dk/slashwin/bard/1"); //TODO: Make the last param matter
+	dbus_start(&bard.dbus, "/dk/slashwin/bard/1", arguments.configDir); //TODO: Increment the name if another instance is running
+	ERROR_ABORT("While starting dbus");
 
 	struct XlibColor xColor;
 
@@ -307,10 +308,14 @@ int main(int argc, char **argv)
 			if(type == WT_DBUS) {
 				if(work.dbus->command == DC_RESTART) {
 					manager_restartBar(&bard.manager);
+					ERROR_ABORT("While restarting lemonbar after dbus signal");
 					render(&bard, separator, monitors);
+					ERROR_ABORT("While rendering bar after dbus restart");
 				} else if(work.dbus->command == DC_RELOAD) {
 					bard_shutdown(&bard);
+					ERROR_ABORT("While stopping bard after dbus reload");
 					startup(&bard, &separator, arguments.configDir, &monitors);
+					ERROR_ABORT("While restarting bard after dbus reload");
 				} else if(work.dbus->command == DC_DISABLEUNIT || work.dbus->command == DC_ENABLEUNIT) {
 					struct Unit* unit = units_find(&bard.units, work.dbus->endis.unitName);
 					if(unit == NULL) {
@@ -323,6 +328,7 @@ int main(int argc, char **argv)
 							J1U(rc, unit->disabledMonitors, work.dbus->endis.monitor);
 						}
 						render(&bard, separator, monitors);
+						ERROR_ABORT("While rendering bar switching unit state for %s", unit->name);
 						free(work.dbus->endis.unitName);
 					}
 				}

--- a/src/myerror.c
+++ b/src/myerror.c
@@ -122,7 +122,7 @@ void error_print() {
 		log_write(LEVEL_FATAL, "No error to print");
 		exit(1);
 	}
-	int index;
+	size_t index;
 	struct Error* err = vector_getFirst(ptr, &index);
 	while(err != NULL) {
 		for(int i = 0; i < index; i++)

--- a/src/output.c
+++ b/src/output.c
@@ -41,64 +41,52 @@ char* out_format(struct Outputs* outs, struct Units* container, int monitors, co
 	Vector* aligns[] = {&container->left, &container->center, &container->right};
 	Vector vec;
 	vector_init(&vec, sizeof(char), 128);
-	if(error_waiting())
-		THROW_CONT(NULL, "While formatting output");
+	PROP_THROW(NULL, "While formatting output");
 	size_t sepLen = strlen(separator);
 	for(int mon = 0; mon < monitors; mon++) {
 		char monStr[33];
 		int monStrLen = snprintf(monStr, 33, "%d", mon);
 		vector_putListBack(&vec, "%{S", 3);
-		if(error_waiting())
-			THROW_CONT(NULL, "While adding monitor output");
+		PROP_THROW(NULL, "While adding monitor output");
 		vector_putListBack(&vec, monStr, monStrLen);
-		if(error_waiting())
-			THROW_CONT(NULL, "While adding monitor output");
+		PROP_THROW(NULL, "While adding monitor output");
 		vector_putListBack(&vec, "}", 1);
-		if(error_waiting())
-			THROW_CONT(NULL, "While adding monitor output");
+		PROP_THROW(NULL, "While adding monitor output");
 		for(int i = ALIGN_FIRST; i <= ALIGN_LAST; i++) {
 			vector_putListBack(&vec, AlignStr[i], strlen(AlignStr[i]));
-			if(error_waiting())
-				THROW_CONT(NULL, "While adding alignment output");
+			PROP_THROW(NULL, "While adding alignment output");
 			size_t index = 0;
 			struct Unit* unit = vector_getFirst(aligns[i], &index);
-			if(error_waiting())
-				THROW_CONT(NULL, "While iterating unit outputs");
+			PROP_THROW(NULL, "While iterating unit outputs");
 			bool first = true;
 			while(unit != NULL) {
 				char** str;
 				JLG(str, outs->outputs, (Word_t)unit);
 				if(str != NULL && str != NULL && *str != NULL && unit->render) {
 					vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
-					if(error_waiting())
-						THROW_CONT(NULL, "While iterating unit outputs");
+					PROP_THROW(NULL, "While iterating unit outputs");
 
 					if(!first) {
 						vector_putListBack(&vec, separator, sepLen);
-						if(error_waiting())
-							THROW_CONT(NULL, "While iterating unit outputs");
+						PROP_THROW(NULL, "While iterating unit outputs");
 					}
 					first = false;
 
 					vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
-					if(error_waiting())
-						THROW_CONT(NULL, "While iterating unit outputs");
+					PROP_THROW(NULL, "While iterating unit outputs");
 
 					vector_putListBack(&vec, *str, strlen(*str));
-					if(error_waiting())
-						THROW_CONT(NULL, "While iterating unit outputs");
+					PROP_THROW(NULL, "While iterating unit outputs");
 				}
 				unit = vector_getNext(aligns[i], &index);
-				if(error_waiting())
-					THROW_CONT(NULL, "While iterating unit outputs");
+				PROP_THROW(NULL, "While iterating unit outputs");
 			}
 		}
 	}
 	//Remember to add the terminator back on
 	static char term = '\0';
 	vector_putBack(&vec, &term);
-	if(error_waiting())
-		THROW_CONT(NULL, "While adding output terminator");
+	PROP_THROW(NULL, "While adding output terminator");
 	//Copy into new buffer owned by calling function
 	char* buff = vector_detach(&vec);
 	return buff;

--- a/src/output.c
+++ b/src/output.c
@@ -60,23 +60,27 @@ char* out_format(struct Outputs* outs, struct Units* container, int monitors, co
 			PROP_THROW(NULL, "While iterating unit outputs");
 			bool first = true;
 			while(unit != NULL) {
-				char** str;
-				JLG(str, outs->outputs, (Word_t)unit);
-				if(str != NULL && str != NULL && *str != NULL && unit->render) {
-					vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
-					PROP_THROW(NULL, "While iterating unit outputs");
+				int isHidden;
+				J1T(isHidden, unit->disabledMonitors, mon);
+				if(!isHidden && unit->render) {
+					char** str;
+					JLG(str, outs->outputs, (Word_t)unit);
+					if(str != NULL && str != NULL && *str != NULL) {
+						vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
+						PROP_THROW(NULL, "While iterating unit outputs");
 
-					if(!first) {
-						vector_putListBack(&vec, separator, sepLen);
+						if(!first) {
+							vector_putListBack(&vec, separator, sepLen);
+							PROP_THROW(NULL, "While iterating unit outputs");
+						}
+						first = false;
+
+						vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
+						PROP_THROW(NULL, "While iterating unit outputs");
+
+						vector_putListBack(&vec, *str, strlen(*str));
 						PROP_THROW(NULL, "While iterating unit outputs");
 					}
-					first = false;
-
-					vector_putListBack(&vec, "%{F-}%{B-}%{T-}", 15);
-					PROP_THROW(NULL, "While iterating unit outputs");
-
-					vector_putListBack(&vec, *str, strlen(*str));
-					PROP_THROW(NULL, "While iterating unit outputs");
 				}
 				unit = vector_getNext(aligns[i], &index);
 				PROP_THROW(NULL, "While iterating unit outputs");

--- a/src/unit.c
+++ b/src/unit.c
@@ -43,7 +43,9 @@ void unit_init(struct Unit* unit) {
 	unit->fontMap = NULL;
 	unit->lEnvKey = 0;
 	unit->envMap = NULL;
-	
+
+	unit->disabledMonitors = NULL;
+
 	unit->delimiter = NULL;
 
 	unit->hash = 0;

--- a/src/unit.h
+++ b/src/unit.h
@@ -59,6 +59,8 @@ struct Unit {
 	size_t lEnvKey;
 	Pvoid_t envMap; // str -> str
 
+	Pvoid_t disabledMonitors;
+
 	char* delimiter;
 
 	/* Processing info */

--- a/src/unitcontainer.c
+++ b/src/unitcontainer.c
@@ -185,3 +185,40 @@ void units_preprocess(struct Units* units) {
 	vector_foreach(&units->right, unit_preprocess, NULL);
 	VPROP_THROW("While preprocessing the right side");
 }
+
+struct MatchData {
+	char* name;
+	struct Unit* result;
+};
+bool match(void* elem, void* userdata) {
+	struct Unit* unit = (struct Unit*)elem;
+	struct MatchData* data = (struct MatchData*)userdata;
+	if(strcmp(data->name, unit->name) == 0) {
+		log_write(LEVEL_INFO, "Found the unit %s", unit->name);
+		data->result = unit;
+		return false;
+	}
+	return true;
+}
+
+struct Unit* units_find(struct Units* units, char* name) {
+	struct MatchData data = {
+		.name = name
+	};
+
+	bool found = vector_foreach(&units->left, match, &data);
+	PROP_THROW(NULL, "While searching the left side");
+	if(!found)
+		return data.result;
+
+	found = vector_foreach(&units->center, match, &data);
+	PROP_THROW(NULL, "While searching the center");
+	if(!found)
+		return data.result;
+
+	found = vector_foreach(&units->right, match, &data);
+	PROP_THROW(NULL, "While searching the right side");
+	if(!found)
+		return data.result;
+	return NULL;
+}

--- a/src/unitcontainer.h
+++ b/src/unitcontainer.h
@@ -30,4 +30,6 @@ void units_free(struct Units* units);
 void units_load(struct Units* units, char* configDir);
 void units_preprocess(struct Units* units);
 
+struct Unit* units_find(struct Units* units, char* name);
+
 #endif

--- a/src/unitexecute.c
+++ b/src/unitexecute.c
@@ -24,8 +24,6 @@
 #include "logger.h"
 #include "myerror.h"
 
-static int min(int a, int b) { return a < b ? a : b; }
-
 static unsigned long hashString(char *str)
 {
 	unsigned long hash = 5381;

--- a/src/workmanager.c
+++ b/src/workmanager.c
@@ -167,6 +167,7 @@ enum WorkType workmanager_next(struct WorkManager* manager, struct Dbus* dbus, u
 			log_write(LEVEL_INFO, "%d events fired", ready);
 			//Check for dbus event
 			if(FD_ISSET(dbus_getfd(dbus), &newSet)) {
+				log_write(LEVEL_INFO, "Dbus work!");
 				struct DbusWork* dwork = NULL;
 				read(dbus_getfd(dbus), &dwork, sizeof(struct DbusWork*));
 				work->dbus = dwork;


### PR DESCRIPTION
You can now enable or disable units per monitor.

Okay, thats a bit of a stretch, but at least it's a good step on the direction. You can enable and disable units, per monitor, at runtime, with the dbus interface.

Now i just need to figure out how to store it in the configuration files to solve #7 
